### PR TITLE
Scope pages

### DIFF
--- a/app/client/app/app-entry.ts
+++ b/app/client/app/app-entry.ts
@@ -10,7 +10,12 @@ import { routes } from '@/routes';
 
 @customElement('app-entry')
 export class AppEntry extends LitElement {
-  private router = new Router(this, routes);
+  private router = new Router(this, []);
+
+  constructor() {
+    super();
+    this.router.routes = [...routes(this.router)];
+  }
 
   static styles = [
     reset,

--- a/app/client/app/app-entry.ts
+++ b/app/client/app/app-entry.ts
@@ -6,7 +6,7 @@ import { Router } from '@lit-labs/router';
 import { reset } from '@/styles/reset.styles';
 
 import '@/app/app-frame';
-import { routes } from '@/routes';
+import { routes } from '@/router/routes';
 
 @customElement('app-entry')
 export class AppEntry extends LitElement {

--- a/app/client/app/app-frame.ts
+++ b/app/client/app/app-frame.ts
@@ -6,7 +6,20 @@ import { reset } from '@/styles/reset.styles';
 
 import '@/components/nav-button';
 
-import { routes } from '@/routes';
+const navItems = [
+  {
+    path: '/',
+    name: 'Home',
+  },
+  {
+    path: '/about',
+    name: 'About',
+  },
+  {
+    path: '/cats',
+    name: 'Cats',
+  },
+];
 
 @customElement('app-frame')
 export class AppFrame extends LitElement {
@@ -36,7 +49,7 @@ export class AppFrame extends LitElement {
           <nav>
             <div class="nav-content">
               ${map(
-                routes,
+                navItems,
                 (route) =>
                   html`<nav-button href=${route.path}
                     >${route.name}</nav-button

--- a/app/client/router/createRoute.ts
+++ b/app/client/router/createRoute.ts
@@ -1,5 +1,7 @@
 import { type CSSResult, type TemplateResult, render } from 'lit';
 
+import { RouteConfig } from '@lit-labs/router';
+
 import { autoBind } from '@/util/autobind';
 
 type Options =
@@ -81,11 +83,11 @@ export function route<T extends Record<string, unknown>>(
       }
       return el;
     };
-    return routeOptions;
+    return routeOptions as RouteConfig;
   }
 
   return {
     path,
     render: (properties: T) => renderFn({ ...typedProps, ...properties }),
-  };
+  } as RouteConfig;
 }

--- a/app/client/router/createRoute.ts
+++ b/app/client/router/createRoute.ts
@@ -1,0 +1,91 @@
+import { type CSSResult, type TemplateResult, render } from 'lit';
+
+import { autoBind } from '@/util/autobind';
+
+type Options =
+  | { scoped: true; tagName: string; styles?: CSSResult }
+  | { scoped?: false; tagName?: string };
+
+type GenericProps<T extends Record<string, unknown>> = {
+  options?: Options;
+} & Partial<T>;
+
+export function route<T extends Record<string, unknown>>(
+  path: string,
+  renderFn: (properties: T) => TemplateResult | HTMLElement,
+  props?: GenericProps<T>,
+) {
+  const routeOptions = {
+    path,
+    render: renderFn,
+  };
+
+  const typedProps = props ? (props as unknown as T) : ({} as T);
+  const options = props?.options;
+  if (options?.scoped) {
+    const tagName = options.tagName;
+
+    if (customElements.get(tagName) === undefined) {
+      class RouteElement extends HTMLElement {
+        private __stylesheet?: CSSStyleSheet;
+        shadowRoot!: ShadowRoot;
+
+        constructor() {
+          super();
+          autoBind(this);
+
+          this.attachShadow({ mode: 'open' });
+        }
+
+        private get _attributes() {
+          return Object.fromEntries(
+            Array.from(this.attributes).map((attribute) => {
+              return [attribute.name, attribute.value];
+            }),
+          );
+        }
+
+        connectedCallback() {
+          if (options?.scoped && options?.styles) {
+            const styles = options?.styles;
+            this.__stylesheet = new CSSStyleSheet();
+            this.__stylesheet.replaceSync(styles.cssText);
+            if (this.shadowRoot) {
+              this.shadowRoot.adoptedStyleSheets = [this.__stylesheet];
+            }
+          }
+
+          render(
+            renderFn({ ...typedProps, ...this._attributes }),
+            this.shadowRoot,
+          );
+        }
+
+        _update() {
+          render(
+            renderFn({ ...typedProps, ...this._attributes }),
+            this.shadowRoot,
+          );
+        }
+      }
+
+      customElements.define(tagName, RouteElement);
+    }
+
+    routeOptions.render = (properties: T) => {
+      const el = document.createElement(tagName);
+      for (const [prop, value] of Object.entries(properties)) {
+        if (typeof value === 'string' || typeof value === 'number') {
+          el.setAttribute(prop, value.toString());
+        }
+      }
+      return el;
+    };
+    return routeOptions;
+  }
+
+  return {
+    path,
+    render: (properties: T) => renderFn({ ...typedProps, ...properties }),
+  };
+}

--- a/app/client/router/routes.ts
+++ b/app/client/router/routes.ts
@@ -1,8 +1,8 @@
 import { Router } from '@lit-labs/router';
 
-import { route } from './router/createRoute';
-import * as about from './routes/about';
-import * as home from './routes/home';
+import { route } from '@/router/createRoute';
+import * as about from '@/routes/about';
+import * as home from '@/routes/home';
 
 export const routes = (router: Router) => [
   route('/', home.Page, { title: 'Project Template 2024' }),

--- a/app/client/routes.ts
+++ b/app/client/routes.ts
@@ -1,23 +1,35 @@
-import { createComponent } from '../renderer/createComponent';
+import { Router } from '@lit-labs/router';
 
+import { route } from './router/createRoute';
 import * as about from './routes/about';
-import * as cats from './routes/cats';
 import * as home from './routes/home';
 
-export const routes = [
+export const routes = (router: Router) => [
+  route('/', home.Page, { title: 'Project Template 2024' }),
+  route('/about', about.Page),
   {
-    name: 'Home',
-    path: '/',
-    render: () => home.Page({ title: 'Project Template 2024' }),
-  },
-  {
-    name: 'About',
-    path: '/about',
-    render: about.Page,
-  },
-  {
-    name: 'Cats',
-    path: '/cats',
-    render: createComponent({ ...cats, title: 'Cat gallery' }),
+    path: '/*',
+    enter: async (params: { [key: string]: string | undefined }) => {
+      const path = params[0];
+      if (path === 'cats') {
+        const cats = await import('@/routes/cats');
+        const { routes } = router;
+        routes.splice(
+          routes.length - 1,
+          0,
+          route('/cats', cats.Page, {
+            title: 'Cat gallery',
+            options: {
+              scoped: true,
+              tagName: 'route-cat-gallery',
+              styles: cats.styles,
+            },
+          }),
+        );
+        await router.goto('/' + path);
+        return false;
+      }
+      return true;
+    },
   },
 ];

--- a/app/client/routes/cats.ts
+++ b/app/client/routes/cats.ts
@@ -28,6 +28,7 @@ export const styles = css`
 `;
 
 export const tagName = 'page-cats';
+
 export type PageProps = {
   title: string;
 };

--- a/app/client/util/autobind.ts
+++ b/app/client/util/autobind.ts
@@ -1,0 +1,22 @@
+export function autoBind<T extends object>(instance: T): void {
+  const prototype = Object.getPrototypeOf(instance);
+  const propertyNames = Object.getOwnPropertyNames(prototype) as Array<keyof T>;
+
+  for (const name of propertyNames) {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
+    if (
+      descriptor &&
+      typeof descriptor.value === 'function' &&
+      name !== 'constructor'
+    ) {
+      const method = descriptor.value as unknown as (
+        ...args: unknown[]
+      ) => unknown;
+      Object.defineProperty(instance, name, {
+        value: method.bind(instance),
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+}

--- a/app/renderer/createComponent.ts
+++ b/app/renderer/createComponent.ts
@@ -1,5 +1,7 @@
 import { type CSSResult, type TemplateResult, render } from 'lit';
 
+import { autoBind } from '@/util/autobind';
+
 export type ComponentProps<T extends { [key: string]: unknown }> = {
   Page: (properties: T) => TemplateResult;
   styles?: CSSResult;
@@ -21,6 +23,8 @@ export function createComponent<T extends { [key: string]: unknown }>({
 
       constructor() {
         super();
+        autoBind(this);
+
         this.attachShadow({ mode: 'open' });
       }
 

--- a/app/renderer/createComponent.ts
+++ b/app/renderer/createComponent.ts
@@ -37,10 +37,7 @@ export function createComponent<T extends { [key: string]: unknown }>({
       }
 
       _update() {
-        render(
-          Page(typedProperties),
-          this.shadowRoot!.getElementById('#component')!,
-        );
+        render(Page(typedProperties), this.shadowRoot);
       }
     }
 

--- a/app/renderer/createComponent.ts
+++ b/app/renderer/createComponent.ts
@@ -17,12 +17,11 @@ export function createComponent<T extends { [key: string]: unknown }>({
   if (customElements.get(tagName) === undefined) {
     class RouteElement extends HTMLElement {
       private __stylesheet?: CSSStyleSheet;
-      private componentContainer = document.createElement('div');
+      shadowRoot!: ShadowRoot;
 
       constructor() {
         super();
         this.attachShadow({ mode: 'open' });
-        this.componentContainer.id = '#component';
       }
 
       connectedCallback() {
@@ -33,12 +32,8 @@ export function createComponent<T extends { [key: string]: unknown }>({
             this.shadowRoot.adoptedStyleSheets = [this.__stylesheet];
           }
         }
-        const fragment = document.createDocumentFragment();
 
-        fragment.appendChild(this.componentContainer);
-
-        render(Page(typedProperties), this.componentContainer);
-        this.shadowRoot!.append(fragment);
+        render(Page(typedProperties), this.shadowRoot);
       }
 
       _update() {

--- a/app/renderer/createComponent.ts
+++ b/app/renderer/createComponent.ts
@@ -3,15 +3,8 @@ import { type CSSResult, type TemplateResult, render } from 'lit';
 export type ComponentProps<T extends { [key: string]: unknown }> = {
   Page: (properties: T) => TemplateResult;
   styles?: CSSResult;
-  tagName?: string;
+  tagName: string;
 } & T;
-
-const uniqueId = (() => {
-  let iterator = 0;
-  return (prefix: string) => {
-    return `${prefix}-${iterator++}`;
-  };
-})();
 
 export function createComponent<T extends { [key: string]: unknown }>({
   Page,
@@ -20,38 +13,42 @@ export function createComponent<T extends { [key: string]: unknown }>({
   ...properties
 }: ComponentProps<T>) {
   const typedProperties = properties as unknown as T;
-  tagName = tagName || uniqueId(`app-custom-tag`);
-
-  class RouteElement extends HTMLElement {
-    private styleContainer = document.createElement('style');
-    private componentContainer = document.createElement('div');
-
-    constructor() {
-      super();
-      this.attachShadow({ mode: 'open' });
-      this.componentContainer.id = '#component';
-    }
-
-    connectedCallback() {
-      const fragment = document.createDocumentFragment();
-      render(styles, this.styleContainer);
-
-      fragment.appendChild(this.styleContainer);
-      fragment.appendChild(this.componentContainer);
-
-      render(Page(typedProperties), this.componentContainer);
-      this.shadowRoot!.append(fragment);
-    }
-
-    _update() {
-      render(
-        Page(typedProperties),
-        this.shadowRoot!.getElementById('#component')!,
-      );
-    }
-  }
 
   if (customElements.get(tagName) === undefined) {
+    class RouteElement extends HTMLElement {
+      private __stylesheet?: CSSStyleSheet;
+      private componentContainer = document.createElement('div');
+
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.componentContainer.id = '#component';
+      }
+
+      connectedCallback() {
+        if (styles) {
+          this.__stylesheet = new CSSStyleSheet();
+          this.__stylesheet.replaceSync(styles.cssText);
+          if (this.shadowRoot) {
+            this.shadowRoot.adoptedStyleSheets = [this.__stylesheet];
+          }
+        }
+        const fragment = document.createDocumentFragment();
+
+        fragment.appendChild(this.componentContainer);
+
+        render(Page(typedProperties), this.componentContainer);
+        this.shadowRoot!.append(fragment);
+      }
+
+      _update() {
+        render(
+          Page(typedProperties),
+          this.shadowRoot!.getElementById('#component')!,
+        );
+      }
+    }
+
     customElements.define(tagName, RouteElement);
   }
 


### PR DESCRIPTION
This PR does a few things.

1. Introduces a `route` that will generate routes for the router.
These routes have options that include
- `scoped`
- `tagName`
- `styles`

When scoped, a route requires a tagName. 
Scoping a route will encapsulate it and its styles within the component.

ATM styles only applies if scoped, global styles should be expected otherwise. 

2. Updates the router in `app-entry` to set up in the constructor
3. Makes `routes` a function

These two make it possible to do dynamic route injection.